### PR TITLE
feat(rules): add rules.Store and in-memory implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,3 @@ go.work.sum
 # IDE things
 .idea
 .vscode
-
-# OSCAL artifacts
-oscal_complete_schema.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  # disallows implicit automatic updating of go.mod and fails when any changes to go.mod are needed
+  modules-download-mode: readonly
 linters:
   enable:
     - errcheck        # Checks for unchecked errors

--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,9 @@ test-unit:
 	go test -race -v -coverprofile=coverage.out ./...
 .PHONY: test-unit
 
-sanity: vendor format vet
-	git diff --exit-code
-.PHONY: sanity
-
 format:
 	go fmt ./...
 .PHONY: format
-
-vet:
-	go vet ./...
-.PHONY: vet
 
 lint:
 	@golangci-lint run ./...

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,17 @@ test-unit:
 	go test -race -v -coverprofile=coverage.out ./...
 .PHONY: test-unit
 
+sanity: vendor format vet
+	git diff --exit-code
+.PHONY: sanity
+
 format:
 	go fmt ./...
 .PHONY: format
+
+vet:
+	go vet ./...
+.PHONY: vet
 
 lint:
 	@golangci-lint run ./...

--- a/extensions/doc.go
+++ b/extensions/doc.go
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ Copyright 2024 The OSCAL Compass Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 /*
 Package extensions defines types that represent OSCAL-based extensions defined by OSCAL Compass.

--- a/extensions/rules.go
+++ b/extensions/rules.go
@@ -2,7 +2,7 @@
 
 package extensions
 
-// Below are defined oscal.Property names for compass-based extensions
+// Below are defined oscal.Property names for compass-based extensions.
 const (
 	RuleIdProp               = "Rule_Id"
 	RuleDescriptionProp      = "Rule_Description"

--- a/extensions/rules.go
+++ b/extensions/rules.go
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ Copyright 2024 The OSCAL Compass Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 package extensions
 

--- a/generators/doc.go
+++ b/generators/doc.go
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ Copyright 2024 The OSCAL Compass Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 // Package generators generates OSCAL-based objects for use. This includes loading objects from existing content or
 // generating sample objects.

--- a/generators/loader.go
+++ b/generators/loader.go
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ Copyright 2024 The OSCAL Compass Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 package generators
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module github.com/oscal-compass/oscal-sdk-go
 
 go 1.22.7
 
-require github.com/defenseunicorns/go-oscal v0.6.0
+require (
+	github.com/defenseunicorns/go-oscal v0.6.0
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/defenseunicorns/go-oscal v0.6.0 h1:eflEKfk7edu4L4kWf6aNQpS94ljfGP8lgWpsPYNtE1Q=
 github.com/defenseunicorns/go-oscal v0.6.0/go.mod h1:UHp2yK9ty2mYJDun7oNhbstCq6SAAwP4YGbw9n7uG6o=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rules/doc.go
+++ b/rules/doc.go
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ Copyright 2024 The OSCAL Compass Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 // Package rules defines logic relating to the processing of compass defined Rules.
 package rules

--- a/rules/doc.go
+++ b/rules/doc.go
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package rules defines logic relating to the processing of compass defined Rules.
+package rules

--- a/rules/internal/set.go
+++ b/rules/internal/set.go
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ Copyright 2024 The OSCAL Compass Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 package internal
 

--- a/rules/internal/set.go
+++ b/rules/internal/set.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+// Set represents a set data structure.
+type Set[T comparable] map[T]struct{}
+
+// NewSet returns an initialized set.
+func NewSet[T comparable]() Set[T] {
+	return make(Set[T])
+}
+
+// Add adds item into the set s.
+func (s Set[T]) Add(item T) {
+	s[item] = struct{}{}
+}
+
+// Has checks if the set contains an item.
+func (s Set[T]) Has(item T) bool {
+	_, ok := s[item]
+	return ok
+}

--- a/rules/memory.go
+++ b/rules/memory.go
@@ -13,14 +13,16 @@ import (
 	. "github.com/oscal-compass/oscal-sdk-go/rules/internal"
 )
 
-var _ Store = (*MemoryStore)(nil)
+var (
+	// Store interface check
+	_ Store = (*MemoryStore)(nil)
 
-// ErrRuleNotFound defines an error returned when rule queries fail.
-var ErrRuleNotFound = errors.New("associated rule object not found")
-
-// ErrComponentsNotFound defines an error returned during MemoryStore creation when the input
-// is invalid.
-var ErrComponentsNotFound = errors.New("no components not found")
+	// ErrRuleNotFound defines an error returned when rule queries fail.
+	ErrRuleNotFound = errors.New("associated rule object not found")
+	// ErrComponentsNotFound defines an error returned during MemoryStore creation when the input
+	// is invalid.
+	ErrComponentsNotFound = errors.New("no components not found")
+)
 
 /*
 MemoryStore provides implementation of a memory-based rule.Store.
@@ -45,8 +47,8 @@ type MemoryStore struct {
 	checksByValidationComponent map[string]Set[string]
 }
 
-// NewMemoryStoreWithComponents creates a new memory-based rule finder.
-func NewMemoryStoreWithComponents(components []oscal112.DefinedComponent) (*MemoryStore, error) {
+// NewMemoryStoreFromComponents creates a new memory-based rule finder.
+func NewMemoryStoreFromComponents(components []oscal112.DefinedComponent) (*MemoryStore, error) {
 	if len(components) == 0 {
 		return nil, fmt.Errorf("failed to create memory store from components: %w", ErrComponentsNotFound)
 	}

--- a/rules/memory.go
+++ b/rules/memory.go
@@ -93,7 +93,6 @@ func (m *MemoryStore) indexComponent(component oscal112.DefinedComponent) Set[st
 		ruleSet, ok := m.nodes[ruleIdProp.Value]
 		if !ok {
 			ruleSet = extensions.RuleSet{}
-			m.nodes[ruleIdProp.Value] = ruleSet
 		}
 
 		// A check may or may not be registered.
@@ -133,7 +132,7 @@ func (m *MemoryStore) indexComponent(component oscal112.DefinedComponent) Set[st
 			m.byCheck[placeholderCheck.ID] = ruleSet.Rule.ID
 		}
 		rules.Add(ruleSet.Rule.ID)
-		m.nodes[ruleIdProp.Value] = ruleSet
+		m.nodes[ruleSet.Rule.ID] = ruleSet
 	}
 	if len(checkIds) != 0 {
 		m.checksByValidationComponent[component.Title] = checkIds

--- a/rules/memory.go
+++ b/rules/memory.go
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ Copyright 2024 The OSCAL Compass Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 package rules
 

--- a/rules/memory.go
+++ b/rules/memory.go
@@ -15,10 +15,10 @@ import (
 
 var _ Store = (*MemoryStore)(nil)
 
-// ErrRuleNotFound defines an error return when rule queries fail.
+// ErrRuleNotFound defines an error returned when rule queries fail.
 var ErrRuleNotFound = errors.New("associated rule object not found")
 
-// ErrComponentsNotFound is return during MemoryStore creation when the input
+// ErrComponentsNotFound defines an error returned during MemoryStore creation when the input
 // is invalid.
 var ErrComponentsNotFound = errors.New("no components not found")
 

--- a/rules/memory.go
+++ b/rules/memory.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	oscal112 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
+
+	"github.com/oscal-compass/oscal-sdk-go/extensions"
+	. "github.com/oscal-compass/oscal-sdk-go/rules/internal"
+)
+
+var _ Store = (*MemoryStore)(nil)
+
+// ErrRuleNotFound defines an error return when rule queries fail.
+var ErrRuleNotFound = errors.New("associated rule object not found")
+
+// ErrComponentsNotFound is return during MemoryStore creation when the input
+// is invalid.
+var ErrComponentsNotFound = errors.New("no components not found")
+
+/*
+MemoryStore provides implementation of a memory-based rule.Store.
+WARNING: This implementation is not thread safe.
+*/
+type MemoryStore struct {
+	// nodes saves the rule ID map keys, which are used with
+	// the other fields.
+	nodes map[string]extensions.RuleSet
+	// ByCheck store a mapping between the checkId and its parent
+	// ruleId
+	byCheck map[string]string
+
+	// Below contains maps that store information by component and
+	// component types to form RuleSet with the correct context.
+
+	// rulesByComponent stores the component title of any component
+	// mapped to any relevant rules.
+	rulesByComponent map[string]Set[string]
+	// checksByValidationComponent store checkId mapped to validation
+	// component title to filter check information on rules.
+	checksByValidationComponent map[string]Set[string]
+}
+
+// NewMemoryStoreWithComponents creates a new memory-based rule finder.
+func NewMemoryStoreWithComponents(components []oscal112.DefinedComponent) (*MemoryStore, error) {
+	if len(components) == 0 {
+		return nil, fmt.Errorf("failed to create memory store from components: %w", ErrComponentsNotFound)
+	}
+	store := &MemoryStore{
+		nodes:                       make(map[string]extensions.RuleSet),
+		byCheck:                     make(map[string]string),
+		rulesByComponent:            make(map[string]Set[string]),
+		checksByValidationComponent: make(map[string]Set[string]),
+	}
+
+	for _, component := range components {
+		extractedRules := store.indexComponent(component)
+		if len(extractedRules) != 0 {
+			store.rulesByComponent[component.Title] = extractedRules
+		}
+	}
+
+	return store, nil
+}
+
+func (m *MemoryStore) indexComponent(component oscal112.DefinedComponent) Set[string] {
+	rules := NewSet[string]()
+	if component.Props == nil {
+		return rules
+	}
+
+	// Catalog all registered check implementations by validation component for filtering in
+	// `rules.FindByComponent`.
+	checkIds := NewSet[string]()
+
+	// Each rule set is linked by a group id in the property remarks
+	byRemarks := groupPropsByRemarks(*component.Props)
+	for _, propSet := range byRemarks {
+		ruleIdProp, ok := findProp(extensions.RuleIdProp, propSet)
+		if !ok {
+			continue
+		}
+
+		ruleSet, ok := m.nodes[ruleIdProp.Value]
+		if !ok {
+			ruleSet = extensions.RuleSet{}
+			m.nodes[ruleIdProp.Value] = ruleSet
+		}
+
+		// A check may or may not be registered.
+		placeholderCheck := extensions.Check{}
+
+		for prop := range propSet {
+			switch prop.Name {
+			case extensions.RuleIdProp:
+				ruleSet.Rule.ID = prop.Value
+			case extensions.RuleDescriptionProp:
+				ruleSet.Rule.Description = prop.Value
+			case extensions.ParameterIdProp:
+				if ruleSet.Rule.Parameter == nil {
+					ruleSet.Rule.Parameter = &extensions.Parameter{}
+				}
+				ruleSet.Rule.Parameter.ID = prop.Value
+			case extensions.ParameterDescriptionProp:
+				if ruleSet.Rule.Parameter == nil {
+					ruleSet.Rule.Parameter = &extensions.Parameter{}
+				}
+				ruleSet.Rule.Parameter.Description = prop.Value
+
+			case extensions.ParameterDefaultProp:
+				if ruleSet.Rule.Parameter == nil {
+					ruleSet.Rule.Parameter = &extensions.Parameter{}
+				}
+				ruleSet.Rule.Parameter.Value = prop.Value
+			case extensions.CheckIdProp:
+				placeholderCheck.ID = prop.Value
+			case extensions.CheckDescriptionProp:
+				placeholderCheck.Description = prop.Value
+			}
+		}
+
+		if placeholderCheck.ID != "" {
+			ruleSet.Checks = append(ruleSet.Checks, placeholderCheck)
+			m.byCheck[placeholderCheck.ID] = ruleSet.Rule.ID
+		}
+		rules.Add(ruleSet.Rule.ID)
+		m.nodes[ruleIdProp.Value] = ruleSet
+	}
+	if len(checkIds) != 0 {
+		m.checksByValidationComponent[component.Title] = checkIds
+	}
+
+	return rules
+}
+
+func (m *MemoryStore) GetByRuleID(_ context.Context, ruleId string) (extensions.RuleSet, error) {
+	ruleSet, ok := m.nodes[ruleId]
+	if !ok {
+		return extensions.RuleSet{}, fmt.Errorf("rule %q: %w", ruleId, ErrRuleNotFound)
+	}
+	return ruleSet, nil
+}
+
+func (m *MemoryStore) GetByCheckID(ctx context.Context, checkId string) (extensions.RuleSet, error) {
+	ruleId, ok := m.byCheck[checkId]
+	if !ok {
+		return extensions.RuleSet{}, fmt.Errorf("failed to find rule for check %q: %w", checkId, ErrRuleNotFound)
+	}
+	return m.GetByRuleID(ctx, ruleId)
+}
+
+func (m *MemoryStore) FindByComponent(ctx context.Context, componentId string) ([]extensions.RuleSet, error) {
+	ruleIds, ok := m.rulesByComponent[componentId]
+	if !ok {
+		return nil, fmt.Errorf("failed to find rules for component %q", componentId)
+	}
+
+	var ruleSets []extensions.RuleSet
+	var errs error
+	for ruleId := range ruleIds {
+		ruleSet, err := m.GetByRuleID(ctx, ruleId)
+		errs = errors.Join(err)
+
+		// Make sure we are only returning the relevant checks for this
+		// component.
+		if checkIds, ok := m.checksByValidationComponent[componentId]; ok {
+			filteredChecks := make([]extensions.Check, 0, len(ruleSet.Checks))
+			for _, check := range ruleSet.Checks {
+				if checkIds.Has(check.ID) {
+					filteredChecks = append(filteredChecks, check)
+				}
+			}
+			ruleSet.Checks = filteredChecks
+		}
+
+		ruleSets = append(ruleSets, ruleSet)
+	}
+
+	if errs != nil {
+		return ruleSets, fmt.Errorf("failed to find rules for component %q: %w", componentId, errs)
+	}
+
+	return ruleSets, nil
+}
+
+func (m *MemoryStore) All(ctx context.Context) ([]extensions.RuleSet, error) {
+	var ruleSets []extensions.RuleSet
+	for _, rule := range m.nodes {
+		ruleSets = append(ruleSets, rule)
+	}
+	return ruleSets, nil
+}

--- a/rules/memory_test.go
+++ b/rules/memory_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	oscaltypes112 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oscal-compass/oscal-sdk-go/extensions"
+	"github.com/oscal-compass/oscal-sdk-go/generators"
+)
+
+var (
+	expectedCertFileRule = extensions.RuleSet{
+		Rule: extensions.Rule{
+			ID:          "etcd_cert_file",
+			Description: "Ensure that the --cert-file argument is set as appropriate",
+		},
+		Checks: []extensions.Check{
+			{
+				ID:          "etcd_cert_file",
+				Description: "Check that the --cert-file argument is set as appropriate",
+			},
+		},
+	}
+	expectedKeyFileRule = extensions.RuleSet{
+		Rule: extensions.Rule{
+			ID:          "etcd_key_file",
+			Description: "Ensure that the --key-file argument is set as appropriate",
+			Parameter: &extensions.Parameter{
+				ID:          "file_name",
+				Description: "A parameter for a file name",
+			},
+		},
+		Checks: []extensions.Check{
+			{
+				ID:          "etcd_key_file",
+				Description: "Check that the --key-file argument is set as appropriate",
+			},
+		},
+	}
+)
+
+func TestIndexComponents(t *testing.T) {
+	tests := []struct {
+		name         string
+		testDataPath string
+		expError     string
+		wantNodes    map[string]extensions.RuleSet
+	}{
+		{
+			name:         "Valid/WithRules",
+			testDataPath: "testdata/component-definition-test.json",
+			wantNodes: map[string]extensions.RuleSet{
+				"etcd_key_file": expectedKeyFileRule,
+
+				"etcd_cert_file": expectedCertFileRule,
+			},
+		},
+		{
+			name:         "Valid/NoRules",
+			testDataPath: "testdata/component-definition-no-rules.json",
+			wantNodes:    map[string]extensions.RuleSet{},
+		},
+		{
+			name:         "Failure/NoComponents",
+			testDataPath: "testdata/component-definition-no-components.json",
+			expError:     "failed to create memory store from components: no components not found",
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			file, err := os.Open(c.testDataPath)
+			require.NoError(t, err)
+			definition, err := generators.NewComponentDefinition(file)
+			require.NoError(t, err)
+
+			if definition.Components == nil {
+				definition.Components = &[]oscaltypes112.DefinedComponent{}
+			}
+
+			testMemory, err := NewMemoryStoreWithComponents(*definition.Components)
+
+			if c.expError != "" {
+				require.EqualError(t, err, c.expError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.wantNodes, testMemory.nodes)
+			}
+		})
+	}
+}
+
+func TestMemoryStore_GetByRuleID(t *testing.T) {
+	testMemory := prepMemoryStore(t)
+	testCtx := context.Background()
+
+	found, err := testMemory.GetByRuleID(testCtx, "etcd_cert_file")
+	require.NoError(t, err)
+
+	expectedRule := extensions.RuleSet{
+		Rule: extensions.Rule{
+			ID:          "etcd_cert_file",
+			Description: "Ensure that the --cert-file argument is set as appropriate",
+		},
+		Checks: []extensions.Check{
+			{
+				ID:          "etcd_cert_file",
+				Description: "Check that the --cert-file argument is set as appropriate",
+			},
+		},
+	}
+	require.Equal(t, expectedRule, found)
+
+	_, err = testMemory.GetByRuleID(testCtx, "not_present")
+	require.EqualError(t, err, "rule \"not_present\": associated rule object not found")
+
+}
+
+func TestMemoryStore_GetByCheckID(t *testing.T) {
+	testMemory := prepMemoryStore(t)
+	testCtx := context.Background()
+
+	found, err := testMemory.GetByCheckID(testCtx, "etcd_key_file")
+	require.NoError(t, err)
+	require.Equal(t, expectedKeyFileRule, found)
+
+	_, err = testMemory.GetByCheckID(testCtx, "not_present")
+	require.EqualError(t, err, "failed to find rule for check \"not_present\": associated rule object not found")
+
+}
+
+func TestMemoryStore_FindByComponent(t *testing.T) {
+	testMemory := prepMemoryStore(t)
+	testCtx := context.Background()
+
+	validatorRuleSet, err := testMemory.FindByComponent(testCtx, "Validator")
+	require.NoError(t, err)
+	softwareRuleSet, err := testMemory.FindByComponent(testCtx, "Kubernetes")
+	require.NoError(t, err)
+
+	require.Contains(t, validatorRuleSet, expectedCertFileRule)
+	require.Contains(t, validatorRuleSet, expectedKeyFileRule)
+	require.Contains(t, softwareRuleSet, expectedCertFileRule)
+	require.Contains(t, softwareRuleSet, expectedKeyFileRule)
+
+	_, err = testMemory.FindByComponent(testCtx, "not_a_component")
+	require.EqualError(t, err, "failed to find rules for component \"not_a_component\"")
+}
+
+func prepMemoryStore(t *testing.T) *MemoryStore {
+	testDataPath := "testdata/component-definition-test.json"
+
+	file, err := os.Open(testDataPath)
+	require.NoError(t, err)
+	definition, err := generators.NewComponentDefinition(file)
+	require.NoError(t, err)
+	testMemory, err := NewMemoryStoreWithComponents(*definition.Components)
+	require.NoError(t, err)
+
+	return testMemory
+}

--- a/rules/memory_test.go
+++ b/rules/memory_test.go
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ Copyright 2024 The OSCAL Compass Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 package rules
 

--- a/rules/memory_test.go
+++ b/rules/memory_test.go
@@ -84,7 +84,7 @@ func TestIndexComponents(t *testing.T) {
 				definition.Components = &[]oscaltypes112.DefinedComponent{}
 			}
 
-			testMemory, err := NewMemoryStoreWithComponents(*definition.Components)
+			testMemory, err := NewMemoryStoreFromComponents(*definition.Components)
 
 			if c.expError != "" {
 				require.EqualError(t, err, c.expError)
@@ -160,7 +160,7 @@ func prepMemoryStore(t *testing.T) *MemoryStore {
 	require.NoError(t, err)
 	definition, err := generators.NewComponentDefinition(file)
 	require.NoError(t, err)
-	testMemory, err := NewMemoryStoreWithComponents(*definition.Components)
+	testMemory, err := NewMemoryStoreFromComponents(*definition.Components)
 	require.NoError(t, err)
 
 	return testMemory

--- a/rules/props.go
+++ b/rules/props.go
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ Copyright 2024 The OSCAL Compass Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 package rules
 

--- a/rules/props.go
+++ b/rules/props.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	oscal112 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
+
+	. "github.com/oscal-compass/oscal-sdk-go/rules/internal"
+)
+
+// groupPropsByRemarks will return the properties group by the same
+// remark string. This is how properties are grouped to create rule sets.
+func groupPropsByRemarks(props []oscal112.Property) map[string]Set[oscal112.Property] {
+	grouped := map[string]Set[oscal112.Property]{}
+	for _, prop := range props {
+		if prop.Remarks == "" {
+			continue
+		}
+		remarks := prop.Remarks
+		set, ok := grouped[remarks]
+		if !ok {
+			set = NewSet[oscal112.Property]()
+		}
+		set.Add(prop)
+		grouped[remarks] = set
+	}
+	return grouped
+}
+
+// findProp finds a property in a set by the property name.
+func findProp(name string, props Set[oscal112.Property]) (oscal112.Property, bool) {
+	for prop := range props {
+		if prop.Name == name {
+			return prop, true
+		}
+	}
+	return oscal112.Property{}, false
+}

--- a/rules/store.go
+++ b/rules/store.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+
+	"github.com/oscal-compass/oscal-sdk-go/extensions"
+)
+
+// Store defines methods for parsing, storing and searching for rule sets generated from
+// OSCAL components.
+type Store interface {
+	// GetByRuleID return the rule object by the associated id or name.
+	GetByRuleID(ctx context.Context, ruleID string) (extensions.RuleSet, error)
+	// GetByCheckID returns rule object by the associated check id.
+	GetByCheckID(ctx context.Context, checkID string) (extensions.RuleSet, error)
+
+	// FindByComponent find rule objects by the associated component title.
+	// Note that if a component is of type validation, this should only return
+	// checks relevant to that validation component. Target component types (non-validation) should
+	// return all information.
+	FindByComponent(ctx context.Context, componentID string) ([]extensions.RuleSet, error)
+
+	// All lists all indexed rules.
+	All(ctx context.Context) ([]extensions.RuleSet, error)
+}

--- a/rules/store.go
+++ b/rules/store.go
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ Copyright 2024 The OSCAL Compass Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 package rules
 

--- a/rules/store.go
+++ b/rules/store.go
@@ -11,7 +11,7 @@ import (
 	"github.com/oscal-compass/oscal-sdk-go/extensions"
 )
 
-// Store defines methods for parsing, storing and searching for rule sets generated based on
+// Store defines methods for filtering and searching for rule sets generated based on
 // rule/check OSCAL extensions.
 type Store interface {
 	// GetByRuleID return the rule object by the associated id or name.

--- a/rules/store.go
+++ b/rules/store.go
@@ -8,8 +8,8 @@ import (
 	"github.com/oscal-compass/oscal-sdk-go/extensions"
 )
 
-// Store defines methods for parsing, storing and searching for rule sets generated from
-// OSCAL components.
+// Store defines methods for parsing, storing and searching for rule sets generated based on
+// rule/check OSCAL extensions.
 type Store interface {
 	// GetByRuleID return the rule object by the associated id or name.
 	GetByRuleID(ctx context.Context, ruleID string) (extensions.RuleSet, error)

--- a/rules/testdata/component-definition-no-components.json
+++ b/rules/testdata/component-definition-no-components.json
@@ -1,0 +1,11 @@
+{
+  "component-definition": {
+    "uuid": "c14d8812-7098-4a9b-8f89-cba41b6ff0d8",
+    "metadata": {
+      "title": "Component definition",
+      "last-modified": "2023-02-21T06:53:42+00:00",
+      "version": "1.1",
+      "oscal-version": "1.0.2"
+    }
+  }
+}

--- a/rules/testdata/component-definition-no-rules.json
+++ b/rules/testdata/component-definition-no-rules.json
@@ -1,0 +1,58 @@
+{
+  "component-definition": {
+    "uuid": "c14d8812-7098-4a9b-8f89-cba41b6ff0d8",
+    "metadata": {
+      "title": "Component definition",
+      "last-modified": "2023-02-21T06:53:42+00:00",
+      "version": "1.1",
+      "oscal-version": "1.0.2"
+    },
+    "components": [
+      {
+        "uuid": "c8106bc8-5174-4e86-91a4-52f2fe0ed027",
+        "type": "service",
+        "title": "Kubernetes",
+        "description": "Kubernetes",
+        "control-implementations": [
+          {
+            "uuid": "f79d6290-8efa-4ea7-b931-27b8435cf707",
+            "source": "profiles/cis/profile.json",
+            "description": "CIS Profile",
+            "implemented-requirements": [
+              {
+                "uuid": "a1b5b713-52c7-46fb-ab57-ebac7f576b23",
+                "control-id": "CIS-2.1",
+                "description": ""
+              },
+              {
+                "uuid": "bd737295-2dd9-436d-89b4-54a581afa154",
+                "control-id": "CIS-2.2",
+                "description": ""
+              },
+              {
+                "uuid": "a463ae43-f562-434e-a3a4-2eaed2cbec59",
+                "control-id": "CIS-2.3",
+                "description": ""
+              },
+              {
+                "uuid": "22d8d502-a9c2-444a-9a3e-e55c1405f42c",
+                "control-id": "CIS-2.4",
+                "description": ""
+              },
+              {
+                "uuid": "e297ed7f-7a8f-44ed-af58-78b0693f3f4b",
+                "control-id": "CIS-2.5",
+                "description": ""
+              },
+              {
+                "uuid": "13c6e9ee-1c85-440a-bbe9-6a54498fcde2",
+                "control-id": "CIS-2.6",
+                "description": ""
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/rules/testdata/component-definition-test.json
+++ b/rules/testdata/component-definition-test.json
@@ -1,0 +1,139 @@
+{
+  "component-definition": {
+    "uuid": "c14d8812-7098-4a9b-8f89-cba41b6ff0d8",
+    "metadata": {
+      "title": "Component definition",
+      "last-modified": "2023-02-21T06:53:42+00:00",
+      "version": "1.1",
+      "oscal-version": "1.1.2"
+    },
+    "components": [
+      {
+        "uuid": "c8106bc8-5174-4e86-91a4-52f2fe0ed027",
+        "type": "service",
+        "title": "Kubernetes",
+        "description": "Kubernetes",
+        "props": [
+          {
+            "name": "Rule_Id",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "etcd_key_file",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Ensure that the --key-file argument is set as appropriate",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Parameter_Id",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "file_name",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Parameter_Description",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "A parameter for a file name",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Rule_Id",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "etcd_cert_file",
+            "remarks": "rule_set_01"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Ensure that the --cert-file argument is set as appropriate",
+            "remarks": "rule_set_01"
+          }
+        ],
+        "control-implementations": [
+          {
+            "uuid": "f79d6290-8efa-4ea7-b931-27b8435cf707",
+            "source": "profiles/cis/profile.json",
+            "description": "CIS Profile",
+            "implemented-requirements": [
+              {
+                "uuid": "a1b5b713-52c7-46fb-ab57-ebac7f576b23",
+                "control-id": "CIS-2.1",
+                "description": "",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+                    "value": "etcd_cert_file"
+                  },
+                  {
+                    "name": "Rule_Id",
+                    "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+                    "value": "etcd_key_file"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "701c70f1-482b-42b0-a419-9870158cd9e2",
+        "type": "validation",
+        "title": "Validator",
+        "description": "An example validation component",
+        "props": [
+          {
+            "name": "Rule_Id",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "etcd_cert_file",
+            "remarks": "rule_set_08"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Ensure that the --cert-file argument is set as appropriate",
+            "remarks": "rule_set_08"
+          },
+          {
+            "name": "Check_Id",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "etcd_cert_file",
+            "remarks": "rule_set_08"
+          },
+          {
+            "name": "Check_Description",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Check that the --cert-file argument is set as appropriate",
+            "remarks": "rule_set_08"
+          },
+          {
+            "name": "Rule_Id",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "etcd_key_file",
+            "remarks": "rule_set_09"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Ensure that the --key-file argument is set as appropriate",
+            "remarks": "rule_set_10"
+          },
+          {
+            "name": "Check_Id",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "etcd_key_file",
+            "remarks": "rule_set_09"
+          },
+          {
+            "name": "Check_Description",
+            "ns": "http://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Check that the --key-file argument is set as appropriate",
+            "remarks": "rule_set_09"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Creates a way to index and interact with rule set extension data gather from OSCAL Components. Starts with a basic in-memory implementation using maps for efficient searching.

Closes #8 

#### Decisions
> These might need feedback

*Making the Store interface*: It's very likely that other implementations will be needed to scale to larger datasets or to support for concurrent searches. Creating an interface that can be used will allow these implementation to be used easily.
*Adding context to the Store Interface* - Essentially future proofing the interface. Added so that the interface does not need to be broken or rewritten if implementation include the use of remote calls. This is a medium opinion though and I could probably go either way on including this.

## How has this been tested?

- [X] Unit tests added with testdata based testdata from C2P
- [X] Using in a [C2P prototype implementation ](https://github.com/jpower432/compliance-to-policy-go/blob/da718db6d2207288e55e184479965c505230fc3c/v2/framework/manager.go#L20)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] New feature (non-breaking change which adds functionality)

## Quality assurance (all should be covered).

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] All commits are signed-off.