### PR TITLE
feat: support multiple parameters per rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Below is a table to show what is currently supported by the SDK.
 | OSCAL Types with Basic Trestle Extensions | :heavy_check_mark: |
 | OSCAL Schema Validation                   | :heavy_check_mark: |
 | Target Components Extension               | :x:                |
-| Multiple Parameters per Rule              | :x:                |
+| Multiple Parameters per Rule              | :heavy_check_mark: |
 | OSCAL to OSCAL Transformation             | :heavy_check_mark: |
 | OSCAL Constraints Validation              | :x:                |
 

--- a/extensions/rules.go
+++ b/extensions/rules.go
@@ -22,7 +22,7 @@ type Rule struct {
 	// Description defines description of what the rule does.
 	Description string
 	// Parameters are optional information for tuning rule logic.
-	Parameters *[]Parameter
+	Parameters []Parameter
 }
 
 // Check defines a single concrete implementation of a Rule.

--- a/extensions/rules.go
+++ b/extensions/rules.go
@@ -21,8 +21,8 @@ type Rule struct {
 	ID string
 	// Description defines description of what the rule does.
 	Description string
-	// Parameter is optional information for tuning rule logic.
-	Parameter *Parameter
+	// Parameters are optional information for tuning rule logic.
+	Parameters *[]Parameter
 }
 
 // Check defines a single concrete implementation of a Rule.

--- a/models/components/defined_test.go
+++ b/models/components/defined_test.go
@@ -31,7 +31,7 @@ func TestDefinedComponentAdapter(t *testing.T) {
 	require.Equal(t, "TestKubernetes", adapter.Title())
 	require.Equal(t, Service, adapter.Type())
 	require.Equal(t, "c8106bc8-5174-4e86-91a4-52f2fe0ed027", adapter.UUID())
-	require.Len(t, adapter.Props(), 6)
+	require.Len(t, adapter.Props(), 7)
 	systemComp, ok := adapter.AsSystemComponent()
 	require.True(t, ok)
 	require.Equal(t, adapter.UUID(), systemComp.UUID)

--- a/models/plans/plan.go
+++ b/models/plans/plan.go
@@ -202,7 +202,7 @@ func ActivitiesForComponent(ctx context.Context, targetComponentID string, store
 		}
 
 		if rule.Rule.Parameters != nil {
-			for _, rp := range *rule.Rule.Parameters {
+			for _, rp := range rule.Rule.Parameters {
 				parameterProp := oscalTypes.Property{
 					Name:  rp.ID,
 					Value: rp.Value,

--- a/models/plans/plan.go
+++ b/models/plans/plan.go
@@ -201,14 +201,16 @@ func ActivitiesForComponent(ctx context.Context, targetComponentID string, store
 			Steps:           &steps,
 		}
 
-		if rule.Rule.Parameter != nil {
-			parameterProp := oscalTypes.Property{
-				Name:  rule.Rule.Parameter.ID,
-				Value: rule.Rule.Parameter.Value,
-				Ns:    extensions.TrestleNameSpace,
-				Class: extensions.TestParameterClass,
+		if rule.Rule.Parameters != nil {
+			for _, rp := range *rule.Rule.Parameters {
+				parameterProp := oscalTypes.Property{
+					Name:  rp.ID,
+					Value: rp.Value,
+					Ns:    extensions.TrestleNameSpace,
+					Class: extensions.TestParameterClass,
+				}
+				*activity.Props = append(*activity.Props, parameterProp)
 			}
-			*activity.Props = append(*activity.Props, parameterProp)
 		}
 		activities = append(activities, activity)
 	}

--- a/models/plans/plan.go
+++ b/models/plans/plan.go
@@ -201,16 +201,14 @@ func ActivitiesForComponent(ctx context.Context, targetComponentID string, store
 			Steps:           &steps,
 		}
 
-		if rule.Rule.Parameters != nil {
-			for _, rp := range rule.Rule.Parameters {
-				parameterProp := oscalTypes.Property{
-					Name:  rp.ID,
-					Value: rp.Value,
-					Ns:    extensions.TrestleNameSpace,
-					Class: extensions.TestParameterClass,
-				}
-				*activity.Props = append(*activity.Props, parameterProp)
+		for _, rp := range rule.Rule.Parameters {
+			parameterProp := oscalTypes.Property{
+				Name:  rp.ID,
+				Value: rp.Value,
+				Ns:    extensions.TrestleNameSpace,
+				Class: extensions.TestParameterClass,
 			}
+			*activity.Props = append(*activity.Props, parameterProp)
 		}
 		activities = append(activities, activity)
 	}

--- a/rules/memory.go
+++ b/rules/memory.go
@@ -202,10 +202,10 @@ func (m *MemoryStore) indexComponent(component components.Component) (set.Set[st
 			}
 		}
 
-		// Add any parameters that were extract from the
+		// Add any parameters that were extracted from the
 		// properties to the rule
 		if len(paramMap) > 0 {
-			ruleParams := make([]extensions.Parameter, 0)
+			ruleParams := make([]extensions.Parameter, 0, len(paramMap))
 			ruleSet.Rule.Parameters = ruleParams
 			for _, param := range paramMap {
 				ruleSet.Rule.Parameters = append(ruleSet.Rule.Parameters, param)

--- a/rules/memory.go
+++ b/rules/memory.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/oscal-compass/oscal-sdk-go/models/components"
 
@@ -127,32 +128,85 @@ func (m *MemoryStore) indexComponent(component components.Component) (set.Set[st
 		// component.Type().
 		placeholderCheck := extensions.Check{}
 
+		// paramMap stores a map of parameters to their suffix value
+		// of the property name.  Multiple properties contain
+		// data needed to populate each parameter.  As the loop
+		// below iterates over the properties the map of
+		// parameters stored in the map are populated.
+		paramMap := make(map[string]extensions.Parameter)
+
 		for prop := range propSet {
-			switch prop.Name {
+
+			// Split the property name to handle parameters that have
+			// a numerical suffix.  e.g Parameter_Id_1
+			// If the property name contains "Parameter" and has a suffix then
+			// extract the suffix as the key for the map.  Otherwise default
+			// to using "0" as the key (meaning there is only one parameter
+			// contained in the properties).
+			var propName string
+			var propSuffix string
+			propNameParts := strings.Split(prop.Name, "_")
+
+			if len(propNameParts) > 2 && strings.HasPrefix("Parameter", prop.Name) {
+				propPrefix := propNameParts[:len(propNameParts)-1]
+
+				propName = strings.Join(propPrefix, "_")
+				propSuffix = propNameParts[len(propNameParts)-1]
+			} else {
+				propName = prop.Name
+				propSuffix = "0" // Used if property does not have numerical suffix
+			}
+
+			switch propName {
 			case extensions.RuleIdProp:
 				ruleSet.Rule.ID = prop.Value
 			case extensions.RuleDescriptionProp:
 				ruleSet.Rule.Description = prop.Value
-			case extensions.ParameterIdProp:
-				if ruleSet.Rule.Parameter == nil {
-					ruleSet.Rule.Parameter = &extensions.Parameter{}
-				}
-				ruleSet.Rule.Parameter.ID = prop.Value
-			case extensions.ParameterDescriptionProp:
-				if ruleSet.Rule.Parameter == nil {
-					ruleSet.Rule.Parameter = &extensions.Parameter{}
-				}
-				ruleSet.Rule.Parameter.Description = prop.Value
-
-			case extensions.ParameterDefaultProp:
-				if ruleSet.Rule.Parameter == nil {
-					ruleSet.Rule.Parameter = &extensions.Parameter{}
-				}
-				ruleSet.Rule.Parameter.Value = prop.Value
 			case extensions.CheckIdProp:
 				placeholderCheck.ID = prop.Value
 			case extensions.CheckDescriptionProp:
 				placeholderCheck.Description = prop.Value
+			case extensions.ParameterIdProp:
+				p, ok := paramMap[propSuffix]
+				if !ok {
+					paramMap[propSuffix] = extensions.Parameter{
+						ID: prop.Value,
+					}
+				} else {
+					p.ID = prop.Value
+					paramMap[propSuffix] = p
+				}
+			case extensions.ParameterDescriptionProp:
+				p, ok := paramMap[propSuffix]
+				if !ok {
+					paramMap[propSuffix] = extensions.Parameter{
+						Description: prop.Value,
+					}
+				} else {
+					p.Description = prop.Value
+					paramMap[propSuffix] = p
+				}
+			case extensions.ParameterDefaultProp:
+				p, ok := paramMap[propSuffix]
+
+				if !ok {
+					paramMap[propSuffix] = extensions.Parameter{
+						Value: prop.Value,
+					}
+				} else {
+					p.Value = prop.Value
+					paramMap[propSuffix] = p
+				}
+			}
+		}
+
+		// Add any parameters that were extract from the
+		// properties to the rule
+		if len(paramMap) > 0 {
+			ruleParams := make([]extensions.Parameter, 0)
+			ruleSet.Rule.Parameters = &ruleParams
+			for _, param := range paramMap {
+				*ruleSet.Rule.Parameters = append(*ruleSet.Rule.Parameters, param)
 			}
 		}
 
@@ -163,8 +217,8 @@ func (m *MemoryStore) indexComponent(component components.Component) (set.Set[st
 		}
 		rules.Add(ruleSet.Rule.ID)
 		m.nodes[ruleSet.Rule.ID] = ruleSet
-	}
 
+	}
 	return rules, checks
 }
 

--- a/rules/memory.go
+++ b/rules/memory.go
@@ -206,9 +206,9 @@ func (m *MemoryStore) indexComponent(component components.Component) (set.Set[st
 		// properties to the rule
 		if len(paramMap) > 0 {
 			ruleParams := make([]extensions.Parameter, 0)
-			ruleSet.Rule.Parameters = &ruleParams
+			ruleSet.Rule.Parameters = ruleParams
 			for _, param := range paramMap {
-				*ruleSet.Rule.Parameters = append(*ruleSet.Rule.Parameters, param)
+				ruleSet.Rule.Parameters = append(ruleSet.Rule.Parameters, param)
 			}
 		}
 

--- a/rules/memory_test.go
+++ b/rules/memory_test.go
@@ -36,7 +36,7 @@ var (
 		Rule: extensions.Rule{
 			ID:          "etcd_key_file",
 			Description: "Ensure that the --key-file argument is set as appropriate",
-			Parameters: &[]extensions.Parameter{
+			Parameters: []extensions.Parameter{
 				{
 					ID:          "file_name",
 					Description: "A parameter for a file name",

--- a/rules/memory_test.go
+++ b/rules/memory_test.go
@@ -36,10 +36,13 @@ var (
 		Rule: extensions.Rule{
 			ID:          "etcd_key_file",
 			Description: "Ensure that the --key-file argument is set as appropriate",
-			Parameters: &[]extensions.Parameter{{
-				ID:          "file_name",
-				Description: "A parameter for a file name",
-			}},
+			Parameters: &[]extensions.Parameter{
+				{
+					ID:          "file_name",
+					Description: "A parameter for a file name",
+					Value:       "A default value",
+				},
+			},
 		},
 		Checks: []extensions.Check{
 			{
@@ -61,8 +64,15 @@ func TestMemoryStore_IndexAll(t *testing.T) {
 			name:         "Valid/WithRules",
 			testDataPath: "../testdata/component-definition-test.json",
 			wantNodes: map[string]extensions.RuleSet{
-				"etcd_key_file": expectedKeyFileRule,
-
+				"etcd_key_file":  expectedKeyFileRule,
+				"etcd_cert_file": expectedCertFileRule,
+			},
+		},
+		{
+			name:         "Valid/WithRulesMultiParams",
+			testDataPath: "../testdata/component-definition-test-multi-param.json",
+			wantNodes: map[string]extensions.RuleSet{
+				"etcd_key_file":  expectedKeyFileRule,
 				"etcd_cert_file": expectedCertFileRule,
 			},
 		},

--- a/rules/memory_test.go
+++ b/rules/memory_test.go
@@ -36,10 +36,10 @@ var (
 		Rule: extensions.Rule{
 			ID:          "etcd_key_file",
 			Description: "Ensure that the --key-file argument is set as appropriate",
-			Parameter: &extensions.Parameter{
+			Parameters: &[]extensions.Parameter{{
 				ID:          "file_name",
 				Description: "A parameter for a file name",
-			},
+			}},
 		},
 		Checks: []extensions.Check{
 			{

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -30,12 +30,12 @@ type Settings struct {
 // The parameter value is not altered on the original rule set, it is copied and returned with the new rule set.
 func (i Settings) ApplyParameterSettings(set extensions.RuleSet) extensions.RuleSet {
 	if len(i.selectedParameters) > 0 && set.Rule.Parameters != nil {
-		for idx, ruleParam := range *set.Rule.Parameters {
+		for idx, ruleParam := range set.Rule.Parameters {
 			selectedValue, ok := i.selectedParameters[ruleParam.ID]
 			if ok {
 				parameterCopy := ruleParam
 				parameterCopy.Value = selectedValue
-				(*set.Rule.Parameters)[idx] = parameterCopy
+				set.Rule.Parameters[idx] = parameterCopy
 			}
 		}
 	}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -29,12 +29,14 @@ type Settings struct {
 // is returned.
 // The parameter value is not altered on the original rule set, it is copied and returned with the new rule set.
 func (i Settings) ApplyParameterSettings(set extensions.RuleSet) extensions.RuleSet {
-	if len(i.selectedParameters) > 0 && set.Rule.Parameter != nil {
-		selectedValue, ok := i.selectedParameters[set.Rule.Parameter.ID]
-		if ok {
-			parameterCopy := *set.Rule.Parameter
-			parameterCopy.Value = selectedValue
-			set.Rule.Parameter = &parameterCopy
+	if len(i.selectedParameters) > 0 && set.Rule.Parameters != nil {
+		for idx, ruleParam := range *set.Rule.Parameters {
+			selectedValue, ok := i.selectedParameters[ruleParam.ID]
+			if ok {
+				parameterCopy := ruleParam
+				parameterCopy.Value = selectedValue
+				(*set.Rule.Parameters)[idx] = parameterCopy
+			}
 		}
 	}
 	return set

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -29,7 +29,7 @@ type Settings struct {
 // is returned.
 // The parameter value is not altered on the original rule set, it is copied and returned with the new rule set.
 func (i Settings) ApplyParameterSettings(set extensions.RuleSet) extensions.RuleSet {
-	if len(i.selectedParameters) > 0 && set.Rule.Parameters != nil {
+	if len(i.selectedParameters) > 0 {
 		for idx, ruleParam := range set.Rule.Parameters {
 			selectedValue, ok := i.selectedParameters[ruleParam.ID]
 			if ok {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -74,7 +74,6 @@ func TestApplyToComponents(t *testing.T) {
 			postValidationFunc: func(store rules.Store) bool {
 				ruleSet, _ := store.GetByRuleID(context.TODO(), "testRule1")
 				ruleSetParams := *ruleSet.Rule.Parameters
-				fmt.Println(ruleSetParams[0].Value)
 				return ruleSet.Rule.Parameters != nil && ruleSetParams[0].Value == "updatedValue"
 			},
 		},

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -56,7 +56,7 @@ func TestApplyToComponents(t *testing.T) {
 					Rule: extensions.Rule{
 						ID:          "testRule1",
 						Description: "Test Rule",
-						Parameters: &[]extensions.Parameter{{
+						Parameters: []extensions.Parameter{{
 							ID:          "testParam1",
 							Description: "Test Parameter",
 							Value:       "updatedValue",
@@ -73,8 +73,7 @@ func TestApplyToComponents(t *testing.T) {
 			},
 			postValidationFunc: func(store rules.Store) bool {
 				ruleSet, _ := store.GetByRuleID(context.TODO(), "testRule1")
-				ruleSetParams := *ruleSet.Rule.Parameters
-				return ruleSet.Rule.Parameters != nil && ruleSetParams[0].Value == "updatedValue"
+				return ruleSet.Rule.Parameters != nil && ruleSet.Rule.Parameters[0].Value == "updatedValue"
 			},
 		},
 		{
@@ -118,7 +117,7 @@ var (
 		Rule: extensions.Rule{
 			ID:          "testRule1",
 			Description: "Test Rule",
-			Parameters: &[]extensions.Parameter{{
+			Parameters: []extensions.Parameter{{
 				ID:          "testParam1",
 				Description: "Test Parameter",
 			}},
@@ -146,7 +145,7 @@ var (
 		Rule: extensions.Rule{
 			ID:          "testRule3",
 			Description: "Test Rule",
-			Parameters: &[]extensions.Parameter{{
+			Parameters: []extensions.Parameter{{
 				ID:          "testParam3",
 				Description: "Test Parameter",
 				Value:       "default",

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -56,11 +56,11 @@ func TestApplyToComponents(t *testing.T) {
 					Rule: extensions.Rule{
 						ID:          "testRule1",
 						Description: "Test Rule",
-						Parameter: &extensions.Parameter{
+						Parameters: &[]extensions.Parameter{{
 							ID:          "testParam1",
 							Description: "Test Parameter",
 							Value:       "updatedValue",
-						},
+						}},
 					},
 					Checks: []extensions.Check{
 						{
@@ -73,7 +73,9 @@ func TestApplyToComponents(t *testing.T) {
 			},
 			postValidationFunc: func(store rules.Store) bool {
 				ruleSet, _ := store.GetByRuleID(context.TODO(), "testRule1")
-				return ruleSet.Rule.Parameter != nil && ruleSet.Rule.Parameter.Value == ""
+				ruleSetParams := *ruleSet.Rule.Parameters
+				fmt.Println(ruleSetParams[0].Value)
+				return ruleSet.Rule.Parameters != nil && ruleSetParams[0].Value == "updatedValue"
 			},
 		},
 		{
@@ -117,10 +119,10 @@ var (
 		Rule: extensions.Rule{
 			ID:          "testRule1",
 			Description: "Test Rule",
-			Parameter: &extensions.Parameter{
+			Parameters: &[]extensions.Parameter{{
 				ID:          "testParam1",
 				Description: "Test Parameter",
-			},
+			}},
 		},
 		Checks: []extensions.Check{
 			{
@@ -145,11 +147,11 @@ var (
 		Rule: extensions.Rule{
 			ID:          "testRule3",
 			Description: "Test Rule",
-			Parameter: &extensions.Parameter{
+			Parameters: &[]extensions.Parameter{{
 				ID:          "testParam3",
 				Description: "Test Parameter",
 				Value:       "default",
-			},
+			}},
 		},
 		Checks: []extensions.Check{
 			{

--- a/testdata/component-definition-test-multi-param.json
+++ b/testdata/component-definition-test-multi-param.json
@@ -27,19 +27,19 @@
             "remarks": "rule_set_00"
           },
           {
-            "name": "Parameter_Id",
+            "name": "Parameter_Id_1",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "file_name",
             "remarks": "rule_set_00"
           },
           {
-            "name": "Parameter_Description",
+            "name": "Parameter_Description_1",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "A parameter for a file name",
             "remarks": "rule_set_00"
           },
           {
-            "name": "Parameter_Value_Default",
+            "name": "Parameter_Value_Default_1",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
             "value": "A default value",
             "remarks": "rule_set_00"


### PR DESCRIPTION
## Description

This PR introduces support for multiple parameters per rule.  This allows component definitions to include more than one parameter in the component properties. 

Example:
```
          {
            "name": "Parameter_Id_1",
            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
            "value": "param_1",
            "remarks": "rule_set_00"
          },
          {
            "name": "Parameter_Id_2",
            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
            "value": "param_2",
            "remarks": "rule_set_00"
          },
```

Fixes # https://github.com/oscal-compass/oscal-sdk-go/issues/35

## How has this been tested?

- [X] Existing unit tests updated to validate changes
- [X] Additional test coverage added using new test component definition

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Quality assurance (all should be covered).

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] All commits are signed-off.
