### PR TITLE
feat!: add control source to assessment plan reviewed controls

### DIFF
--- a/extensions/props.go
+++ b/extensions/props.go
@@ -35,10 +35,10 @@ const (
 	// TestParameterClass represents the property class for all test parameters
 	// in OSCAL Activity types in Assessment Plans.
 	TestParameterClass = "test-parameter"
-	// AssessmentRuleIdProp represent the property name for a rule associated to an OSCAL
+	// AssessmentRuleIdProp represents the property name for a rule associated to an OSCAL
 	// Observation.
 	AssessmentRuleIdProp = "assessment-rule-id"
-	// AssessmentCheckIdProp represent the property name for a check associated to an OSCAL
+	// AssessmentCheckIdProp represents the property name for a check associated to an OSCAL
 	// Observation.
 	AssessmentCheckIdProp = "assessment-check-id"
 )

--- a/internal/plans/plan_test.go
+++ b/internal/plans/plan_test.go
@@ -174,7 +174,7 @@ func prepSettings(t *testing.T, definition oscalTypes.ComponentDefinition) setti
 		}
 		allImplementations = append(allImplementations, *component.ControlImplementations...)
 	}
-	impSettings, err := settings.Framework("cis", allImplementations)
+	impSettings, _, err := settings.ByFramework("cis", allImplementations)
 	require.NoError(t, err)
 	return *impSettings
 }

--- a/settings/framework.go
+++ b/settings/framework.go
@@ -46,10 +46,18 @@ func GetFrameworkShortName(implementation oscalTypes.ControlImplementationSet) (
 	return "", false
 }
 
-// Framework returns ImplementationSettings from a list of OSCAL Control Implementations for a given framework. If multiple matches are found, the
+// FrameworkSource defines data for a control source or framework.
+type FrameworkSource struct {
+	Title       string
+	Description string
+	Href        string
+}
+
+// ByFramework returns ImplementationSettings and FrameworkSource from a list of OSCAL Control Implementations for a given framework. If multiple matches are found, the
 // implementation settings are merged together.
-func Framework(framework string, controlImplementations []oscalTypes.ControlImplementationSet) (*ImplementationSettings, error) {
+func ByFramework(framework string, controlImplementations []oscalTypes.ControlImplementationSet) (*ImplementationSettings, FrameworkSource, error) {
 	var implementationSettings *ImplementationSettings
+	var frameworkSource FrameworkSource
 
 	for _, controlImplementation := range controlImplementations {
 		frameworkShortName, found := GetFrameworkShortName(controlImplementation)
@@ -57,6 +65,9 @@ func Framework(framework string, controlImplementations []oscalTypes.ControlImpl
 		if found && frameworkShortName == framework {
 			if implementationSettings == nil {
 				implementationSettings = NewImplementationSettings(implementationAdapter)
+				frameworkSource.Description = controlImplementation.Description
+				frameworkSource.Href = controlImplementation.Source
+				frameworkSource.Title = framework
 			} else {
 				implementationSettings.merge(implementationAdapter)
 			}
@@ -64,7 +75,7 @@ func Framework(framework string, controlImplementations []oscalTypes.ControlImpl
 	}
 
 	if implementationSettings == nil {
-		return implementationSettings, fmt.Errorf("framework %s is not in control implementations", framework)
+		return implementationSettings, frameworkSource, fmt.Errorf("framework %s is not in control implementations", framework)
 	}
-	return implementationSettings, nil
+	return implementationSettings, frameworkSource, nil
 }

--- a/settings/framework_test.go
+++ b/settings/framework_test.go
@@ -117,13 +117,13 @@ func TestByFramework(t *testing.T) {
 		},
 	}
 
-	expectedFramwork := FrameworkSource{
+	expectedFramework := FrameworkSource{
 		Title:       "cis",
 		Description: "CIS Profile",
 		Href:        "profiles/cis/profile.json",
 	}
 
-	require.Equal(t, expectedFramwork, framework)
+	require.Equal(t, expectedFramework, framework)
 	require.Equal(t, expectedSettings, implementationsMap)
 
 	_, _, err = ByFramework("doesnotexist", allImplementations)

--- a/settings/framework_test.go
+++ b/settings/framework_test.go
@@ -66,7 +66,7 @@ func TestGetFrameworkShortName(t *testing.T) {
 	}
 }
 
-func TestFramework(t *testing.T) {
+func TestByFramework(t *testing.T) {
 	testDataPath := filepath.Join("../testdata", "component-definition-test-reqs.json")
 	file, err := os.Open(testDataPath)
 	require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestFramework(t *testing.T) {
 		allImplementations = append(allImplementations, *component.ControlImplementations...)
 	}
 
-	implementationsMap, err := Framework("cis", allImplementations)
+	implementationsMap, framework, err := ByFramework("cis", allImplementations)
 	require.NoError(t, err)
 	expectedSettings := &ImplementationSettings{
 		settings: Settings{
@@ -117,8 +117,15 @@ func TestFramework(t *testing.T) {
 		},
 	}
 
+	expectedFramwork := FrameworkSource{
+		Title:       "cis",
+		Description: "CIS Profile",
+		Href:        "profiles/cis/profile.json",
+	}
+
+	require.Equal(t, expectedFramwork, framework)
 	require.Equal(t, expectedSettings, implementationsMap)
 
-	_, err = Framework("doesnotexist", allImplementations)
+	_, _, err = ByFramework("doesnotexist", allImplementations)
 	require.EqualError(t, err, "framework doesnotexist is not in control implementations")
 }

--- a/settings/implementation_test.go
+++ b/settings/implementation_test.go
@@ -272,7 +272,7 @@ func prepSettings(t *testing.T) *ImplementationSettings {
 		}
 		allImplementations = append(allImplementations, *component.ControlImplementations...)
 	}
-	impSettings, err := Framework("cis", allImplementations)
+	impSettings, _, err := ByFramework("cis", allImplementations)
 	require.NoError(t, err)
 	return impSettings
 }

--- a/transformers/transformer_example_test.go
+++ b/transformers/transformer_example_test.go
@@ -30,12 +30,12 @@ func ExampleComponentDefinitionsToAssessmentPlan() {
 		if err != nil {
 			log.Fatalf("failed to create assessment plan, %v", err)
 		}
-		reviewedControlsJson, err := json.Marshal(assessmentPlan.ReviewedControls)
+		reviewedControlsJson, err := json.Marshal(assessmentPlan.ReviewedControls.ControlSelections)
 		if err != nil {
 			log.Fatalf("failed to marshal reviewed controls, %v", err)
 		}
 		fmt.Println(string(reviewedControlsJson))
 	}
 	// Output:
-	// {"control-selections":[{"include-controls":[{"control-id":"CIS-2.1"}]}]}
+	// [{"include-controls":[{"control-id":"CIS-2.1"}]}]
 }

--- a/transformers/transformer_test.go
+++ b/transformers/transformer_test.go
@@ -7,6 +7,8 @@ package transformers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -49,15 +51,24 @@ func TestComponentDefinitionsToAssessmentPlan(t *testing.T) {
 	// Backmatter check
 	require.Len(t, *plan.BackMatter.Resources, 1)
 	resources := *plan.BackMatter.Resources
-	require.Equal(t, resources[0].Title, "cis")
-	require.Equal(t, resources[0].Description, "CIS Profile")
+	require.Equal(t, "cis", resources[0].Title)
+	require.Equal(t, "CIS Profile", resources[0].Description)
 	require.Len(t, *resources[0].Rlinks, 1)
+
+	// Link check
+	require.Len(t, *plan.ReviewedControls.Links, 1)
+	links := *plan.ReviewedControls.Links
+	require.Equal(t, "includes-controls-from-source", links[0].Rel)
+	require.Equal(t, fmt.Sprintf("#%s", resources[0].UUID), links[0].Href)
 
 	// Validate against the schema
 	validator := validation.NewSchemaValidator()
 	oscalModels := oscalTypes.OscalModels{
 		AssessmentPlan: plan,
 	}
+
+	data, _ := json.MarshalIndent(oscalModels, "", " ")
+	fmt.Println(string(data))
 	require.NoError(t, validator.Validate(oscalModels))
 }
 

--- a/transformers/transformer_test.go
+++ b/transformers/transformer_test.go
@@ -46,6 +46,13 @@ func TestComponentDefinitionsToAssessmentPlan(t *testing.T) {
 	require.Contains(t, activities, "etcd_cert_file")
 	require.Contains(t, activities, "etcd_key_file")
 
+	// Backmatter check
+	require.Len(t, *plan.BackMatter.Resources, 1)
+	resources := *plan.BackMatter.Resources
+	require.Equal(t, resources[0].Title, "cis")
+	require.Equal(t, resources[0].Description, "CIS Profile")
+	require.Len(t, *resources[0].Rlinks, 1)
+
 	// Validate against the schema
 	validator := validation.NewSchemaValidator()
 	oscalModels := oscalTypes.OscalModels{

--- a/transformers/transformers.go
+++ b/transformers/transformers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/defenseunicorns/go-oscal/src/pkg/uuid"
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 
 	"github.com/oscal-compass/oscal-sdk-go/internal/plans"
@@ -36,11 +37,33 @@ func ComponentDefinitionsToAssessmentPlan(ctx context.Context, definitions []osc
 			}
 		}
 	}
-	implementationSettings, err := settings.Framework(framework, allImplementations)
+	implementationSettings, frameworkSrc, err := settings.ByFramework(framework, allImplementations)
 	if err != nil || implementationSettings == nil {
 		return nil, fmt.Errorf("cannot transform definitions for framework %s: %w", framework, err)
 	}
-	return plans.GenerateAssessmentPlan(ctx, allComponents, *implementationSettings)
+	assessmentPlan, err := plans.GenerateAssessmentPlan(ctx, allComponents, *implementationSettings)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add control source resource to maintain traceability to original control set.
+	controlSource := oscalTypes.Resource{
+		UUID:        uuid.NewUUID(),
+		Description: frameworkSrc.Description,
+		Title:       frameworkSrc.Title,
+		Rlinks: &[]oscalTypes.ResourceLink{
+			{
+				MediaType: "application/json",
+				Href:      frameworkSrc.Href,
+			},
+		},
+	}
+	backmatter := oscalTypes.BackMatter{
+		Resources: &[]oscalTypes.Resource{controlSource},
+	}
+	assessmentPlan.BackMatter = &backmatter
+
+	return assessmentPlan, nil
 }
 
 // SSPToAssessmentPlan transforms the data from a System Security Plan at a given import location to a single OSCAL Assessment Plan.

--- a/transformers/transformers.go
+++ b/transformers/transformers.go
@@ -53,7 +53,7 @@ func ComponentDefinitionsToAssessmentPlan(ctx context.Context, definitions []osc
 		Title:       frameworkSrc.Title,
 		Rlinks: &[]oscalTypes.ResourceLink{
 			{
-				MediaType: "application/json",
+				MediaType: "application/oscal+json",
 				Href:      frameworkSrc.Href,
 			},
 		},
@@ -62,6 +62,19 @@ func ComponentDefinitionsToAssessmentPlan(ctx context.Context, definitions []osc
 		Resources: &[]oscalTypes.Resource{controlSource},
 	}
 	assessmentPlan.BackMatter = &backmatter
+
+	// Add a link to the ReviewedControls to source
+	sourceRef := oscalTypes.Link{
+		Href: fmt.Sprintf("#%s", controlSource.UUID),
+		Rel:  "includes-controls-from-source",
+		Text: "The reviewed controls are derived from the linked OSCAL profile.",
+	}
+
+	if assessmentPlan.ReviewedControls.Links == nil {
+		assessmentPlan.ReviewedControls.Links = &[]oscalTypes.Link{}
+	}
+
+	*assessmentPlan.ReviewedControls.Links = append(*assessmentPlan.ReviewedControls.Links, sourceRef)
 
 	return assessmentPlan, nil
 }


### PR DESCRIPTION
## Description

To ensure an Assessment Plan created from a set
of Component Definitions can still be traced back to the original control source, the information from the control implementation is added as a backmatter resource.

Fixes #71 

### Rationale

A resource was added to satisfy the requirement instead of a property so more information about the control source could be retained. A link was added under `ReviewedControls` to the resource in the backmatter.

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [x] Unit tests added to transformer

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Quality assurance (all should be covered).

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] All commits are signed-off.
