### PR TITLE
chore: unify oscaltypes import

### DIFF
--- a/rules/memory_test.go
+++ b/rules/memory_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"testing"
 
-	oscaltypes112 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
+	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oscal-compass/oscal-sdk-go/extensions"
@@ -96,7 +96,7 @@ func TestMemoryStore_IndexAll(t *testing.T) {
 			require.NoError(t, err)
 
 			if definition.Components == nil {
-				definition.Components = &[]oscaltypes112.DefinedComponent{}
+				definition.Components = &[]oscalTypes.DefinedComponent{}
 			}
 
 			var comps []components.Component

--- a/rules/props.go
+++ b/rules/props.go
@@ -8,7 +8,7 @@ package rules
 import (
 	"strings"
 
-	oscal112 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
+	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 
 	"github.com/oscal-compass/oscal-sdk-go/extensions"
 	"github.com/oscal-compass/oscal-sdk-go/internal/set"
@@ -16,8 +16,8 @@ import (
 
 // groupPropsByRemarks will return the properties group by the same
 // remark string. This is how properties are grouped to create rule sets.
-func groupPropsByRemarks(props []oscal112.Property) map[string]set.Set[oscal112.Property] {
-	grouped := map[string]set.Set[oscal112.Property]{}
+func groupPropsByRemarks(props []oscalTypes.Property) map[string]set.Set[oscalTypes.Property] {
+	grouped := map[string]set.Set[oscalTypes.Property]{}
 	for _, prop := range props {
 		if prop.Remarks == "" {
 			continue
@@ -25,7 +25,7 @@ func groupPropsByRemarks(props []oscal112.Property) map[string]set.Set[oscal112.
 		remarks := prop.Remarks
 		propSet, ok := grouped[remarks]
 		if !ok {
-			propSet = set.New[oscal112.Property]()
+			propSet = set.New[oscalTypes.Property]()
 		}
 		propSet.Add(prop)
 		grouped[remarks] = propSet
@@ -35,11 +35,11 @@ func groupPropsByRemarks(props []oscal112.Property) map[string]set.Set[oscal112.
 
 // getProp finds a property in a set by the property name. This also implicitly checks the property is a
 // trestle-defined property in the namespace.
-func getProp(name string, props set.Set[oscal112.Property]) (oscal112.Property, bool) {
+func getProp(name string, props set.Set[oscalTypes.Property]) (oscalTypes.Property, bool) {
 	for prop := range props {
 		if prop.Name == name && strings.Contains(prop.Ns, extensions.TrestleNameSpace) {
 			return prop, true
 		}
 	}
-	return oscal112.Property{}, false
+	return oscalTypes.Property{}, false
 }


### PR DESCRIPTION
## Description
Unify the oscal types import.

## Quality assurance (all should be covered).

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] All commits are signed-off.