### PR TITLE
feat: adds props to empty observations to support finding creation

### DIFF
--- a/internal/results/observations.go
+++ b/internal/results/observations.go
@@ -51,7 +51,7 @@ func (o *observationsManager) load(observations []oscalTypes.Observation) {
 }
 
 // createOrGet return an existing observation or a newly created one.
-func (o *observationsManager) createOrGet(checkId string) oscalTypes.Observation {
+func (o *observationsManager) createOrGet(checkId, ruleId string) oscalTypes.Observation {
 	for _, observation := range o.observationsByCheck {
 		// Loop through the Props slice to find the AssessmentCheckIdProp
 		if observation.Props == nil {
@@ -70,10 +70,24 @@ func (o *observationsManager) createOrGet(checkId string) oscalTypes.Observation
 		return observation
 	}
 
+	props := []oscalTypes.Property{
+		{
+			Name:  extensions.AssessmentRuleIdProp,
+			Value: ruleId,
+			Ns:    extensions.TrestleNameSpace,
+		},
+		{
+			Name:  extensions.AssessmentCheckIdProp,
+			Value: checkId,
+			Ns:    extensions.TrestleNameSpace,
+		},
+	}
+
 	emptyObservation := oscalTypes.Observation{
 		UUID:      uuid.NewUUID(),
 		Title:     checkId,
 		Collected: time.Now(),
+		Props:     &props,
 	}
 	o.updateObservation(&emptyObservation)
 	return emptyObservation

--- a/internal/results/results.go
+++ b/internal/results/results.go
@@ -143,7 +143,7 @@ func GenerateAssessmentResults(plan oscalTypes.AssessmentPlan, opts ...GenerateO
 				// One Observation per Activity Step
 				// Observation Title == Check
 				for _, step := range *activity.Steps {
-					observation := observationManager.createOrGet(step.Title)
+					observation := observationManager.createOrGet(step.Title, activity.Title)
 					for _, method := range methods {
 						observation.Methods = append(observation.Methods, method.Value)
 					}

--- a/internal/results/results_test.go
+++ b/internal/results/results_test.go
@@ -334,6 +334,55 @@ func TestGenerateAssessmentResults(t *testing.T) {
 			},
 		},
 		{
+			name: "Success/VerifyCreateOrGetWithProps",
+			inputOptions: []GenerateOption{
+				WithObservations([]oscalTypes.Observation{
+					{
+						Title: "check-1",
+						Props: &[]oscalTypes.Property{
+							{
+								Name:  extensions.AssessmentRuleIdProp,
+								Ns:    extensions.TrestleNameSpace,
+								Value: "rule-1",
+							},
+							{
+								Name:  extensions.AssessmentCheckIdProp,
+								Ns:    extensions.TrestleNameSpace,
+								Value: "check-1",
+							},
+						},
+					},
+				}),
+			},
+			assessmentPlan: defaultAssessmentPlan,
+			assertFunc: func(t *testing.T, results *oscalTypes.AssessmentResults) {
+				require.Len(t, results.Results, 1)
+				result := results.Results[0]
+				require.NotNil(t, result.Observations)
+				require.Len(t, *result.Observations, 1)
+
+				observation := (*result.Observations)[0]
+
+				// Verify that the observation has properties
+				require.NotNil(t, observation.Props)
+				props := *observation.Props
+
+				var ruleIdFound, checkIdFound bool
+				for _, prop := range props {
+					if prop.Name == extensions.AssessmentRuleIdProp && prop.Ns == extensions.TrestleNameSpace {
+						require.Equal(t, "rule-1", prop.Value)
+						ruleIdFound = true
+					}
+					if prop.Name == extensions.AssessmentCheckIdProp && prop.Ns == extensions.TrestleNameSpace {
+						require.Equal(t, "check-1", prop.Value)
+						checkIdFound = true
+					}
+				}
+				require.True(t, ruleIdFound)
+				require.True(t, checkIdFound)
+			},
+		},
+		{
 			name:           "Failure/NoTasksPlan",
 			assessmentPlan: &oscalTypes.AssessmentPlan{},
 			expError:       "assessment plan tasks cannot be empty",


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Adds `assessment-rule-id` and `assessment-check-id` to new observation to support rule specific finding creation

Support linked issue in C2P

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Unit tests added

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Quality assurance (all should be covered).

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] All commits are signed-off.
